### PR TITLE
[MOBILE-69] Stop connection checker when app is closed

### DIFF
--- a/android/app/src/main/java/network/mysterium/vpn/MainActivity.kt
+++ b/android/app/src/main/java/network/mysterium/vpn/MainActivity.kt
@@ -75,6 +75,7 @@ class MainActivity : ReactActivity() {
 
   override fun onDestroy() {
     unbindMysteriumService()
+    connectionChecker.stop()
     super.onDestroy()
   }
 


### PR DESCRIPTION
This fixes bug when disconnect notification is shown in foreground (when clicking "Disconnect") after app restart.