### PR TITLE
Disable advertising ID collection in Firebase

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -35,6 +35,9 @@
       <service android:name=".connection.ConnectionCheckerService" />
 
       <meta-data
+        android:name="google_analytics_adid_collection_enabled"
+        android:value="false" />
+      <meta-data
         android:name="com.dieam.reactnativepushnotification.notification_channel_name"
         android:value="MysteriumVPN notifications" />
       <meta-data


### PR DESCRIPTION
No point to collect "Advertising ID" becaue dVPN dont even use this data