### PR TITLE
Show fail message if feedback send not succeeded

### DIFF
--- a/android/app/src/main/java/network/mysterium/ui/FeedbackFragment.kt
+++ b/android/app/src/main/java/network/mysterium/ui/FeedbackFragment.kt
@@ -73,15 +73,17 @@ class FeedbackFragment : Fragment() {
         }
 
         feedbackSubmitButton.isEnabled = false
-        navigateTo(root, Screen.MAIN)
-        showMessage(root.context, getString(R.string.feedback_submit_success))
 
         // Do not wait for feedback to send response as it may take some time.
         CoroutineScope(Dispatchers.Main).launch {
             try {
                 feedbackViewModel.submit()
+                navigateTo(root, Screen.MAIN)
+                showMessage(root.context, getString(R.string.feedback_submit_success))
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to send user feedback", e)
+                showMessage(root.context, getString(R.string.feedback_submit_failed))
+                feedbackSubmitButton.isEnabled = true
             }
         }
     }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="terms_accept">Accept</string>
     <string name="proposals_close">CLOSE</string>
     <string name="feedback_submit_success">Thanks! Your feedback submitted successfully.</string>
+    <string name="feedback_submit_failed">Failed to send your feedback message. Please try again later.</string>
     <string name="disconnect_to_select_proposal">Disconnect to select new a proposal.</string>
     <string name="connect_button_loading">Loading</string>
     <string name="vpn_status_loading">Loading</string>


### PR DESCRIPTION
We were always showing the success message ignoring problems.
With this fix, the user will get a real message about feedback sending status.

Close: https://github.com/mysteriumnetwork/node/issues/2455