### PR TITLE
Migrate to network callback API

### DIFF
--- a/android/app/src/main/java/network/mysterium/AppContainer.kt
+++ b/android/app/src/main/java/network/mysterium/AppContainer.kt
@@ -20,12 +20,15 @@ package network.mysterium
 import android.app.NotificationManager
 import android.content.ClipboardManager
 import android.content.Context
+import android.net.ConnectivityManager
+import android.net.wifi.WifiManager
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.fragment.app.FragmentActivity
 import androidx.room.Room
 import kotlinx.coroutines.CompletableDeferred
 import network.mysterium.db.AppDatabase
 import network.mysterium.logging.BugReporter
+import network.mysterium.net.NetworkMonitor
 import network.mysterium.service.core.DeferredNode
 import network.mysterium.service.core.MysteriumCoreService
 import network.mysterium.service.core.NodeRepository
@@ -45,6 +48,7 @@ class AppContainer {
     lateinit var appNotificationManager: AppNotificationManager
     lateinit var clipboardManager: ClipboardManager
     lateinit var versionViewModel: VersionViewModel
+    lateinit var networkMonitor: NetworkMonitor
 
     fun init(
             ctx: Context,
@@ -71,6 +75,11 @@ class AppContainer {
         termsViewModel = TermsViewModel(appDatabase)
         versionViewModel = VersionViewModel()
         this.clipboardManager = clipboardManager
+
+        networkMonitor = NetworkMonitor(
+                connectivity = ctx.getSystemService(ConnectivityManager::class.java),
+                wifi = ctx.getSystemService(WifiManager::class.java)
+        )
     }
 
     companion object {

--- a/android/app/src/main/java/network/mysterium/MainActivity.kt
+++ b/android/app/src/main/java/network/mysterium/MainActivity.kt
@@ -20,7 +20,8 @@ package network.mysterium
 import android.app.Activity
 import android.app.NotificationManager
 import android.content.*
-import android.net.VpnService
+import android.net.*
+import android.net.wifi.WifiManager
 import android.os.Bundle
 import android.os.IBinder
 import android.util.Log
@@ -39,7 +40,7 @@ import kotlinx.coroutines.*
 import network.mysterium.service.core.DeferredNode
 import network.mysterium.service.core.MysteriumAndroidCoreService
 import network.mysterium.service.core.MysteriumCoreService
-import network.mysterium.service.core.NetworkConnState
+import network.mysterium.service.core.NetworkState
 import network.mysterium.ui.Screen
 import network.mysterium.ui.navigateTo
 import network.mysterium.vpn.R
@@ -138,26 +139,26 @@ class MainActivity : AppCompatActivity() {
     }
 
     // Start node and load initial data when connected to internet.
-    private fun handleConnChange(networkConnState: NetworkConnState) {
-        Log.i(TAG, "Network connection changed: $networkConnState")
+    private fun handleConnChange(networkState: NetworkState) {
+        Log.i(TAG, "Network connection changed: $networkState")
 
-        vpnNotInternetLayout.visibility = if (networkConnState.connected) {
+        vpnNotInternetLayout.visibility = if (networkState.connected) {
             View.GONE
         } else {
             View.VISIBLE
         }
 
-        startNode(networkConnState)
+        startNode(networkState)
     }
 
-    private fun startNode(networkConnState: NetworkConnState) {
+    private fun startNode(networkState: NetworkState) {
         // Skip if node is already started.
         if (deferredNode.isStarted()) {
             return
         }
 
         // Skip if no internet connection.
-        if (!networkConnState.connected) {
+        if (!networkState.connected) {
             return
         }
 

--- a/android/app/src/main/java/network/mysterium/net/NetworkMonitor.kt
+++ b/android/app/src/main/java/network/mysterium/net/NetworkMonitor.kt
@@ -1,0 +1,71 @@
+package network.mysterium.net
+
+import android.net.*
+import android.net.NetworkCapabilities.TRANSPORT_CELLULAR
+import android.net.NetworkCapabilities.TRANSPORT_WIFI
+import android.net.wifi.WifiInfo
+import android.net.wifi.WifiManager
+import android.util.Log
+import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class NetworkMonitor(
+        private val connectivity: ConnectivityManager,
+        private val wifi: WifiManager
+) : ConnectivityManager.NetworkCallback() {
+
+    companion object {
+        private const val TAG = "NetworkMonitor"
+    }
+
+    val state = MutableLiveData(NetworkState())
+
+    fun startWatching() {
+        connectivity.registerNetworkCallback(NetworkRequest.Builder()
+                .addTransportType(TRANSPORT_WIFI)
+                .addTransportType(TRANSPORT_CELLULAR)
+                .build(),
+                this
+        )
+    }
+
+    override fun onCapabilitiesChanged(network: Network?, networkCapabilities: NetworkCapabilities?) {
+        Log.d(TAG, "onCapabilitiesChanged $network $networkCapabilities")
+        val nc = networkCapabilities ?: return
+        val connected = connectivity.getNetworkInfo(network).isConnected
+        val newState = when {
+            nc.hasTransport(TRANSPORT_CELLULAR) -> {
+                NetworkState(cellularConnected = connected)
+            }
+            nc.hasTransport(TRANSPORT_WIFI) -> {
+                NetworkState(wifiConnected = connected, wifiNetworkId = getWifiNetworkId(wifi))
+            }
+            else -> return
+        }
+
+        // Update state if conn was changed. It could change when switching from Wifi to Mobile network
+        // or other different Wifi networks (in such case wifiConnId is used to check if wifi is changed).
+        if (newState != state.value) {
+            CoroutineScope(Dispatchers.Main).launch {
+                state.value = newState
+                Log.i(TAG, "Network state changed: ${state.value}")
+            }
+        }
+    }
+
+}
+
+fun getWifiNetworkId(manager: WifiManager): Int {
+    if (manager.isWifiEnabled) {
+        val wifiInfo = manager.connectionInfo
+        if (wifiInfo != null) {
+            val state = WifiInfo.getDetailedStateOf(wifiInfo.supplicantState)
+            if (state == NetworkInfo.DetailedState.CONNECTED || state == NetworkInfo.DetailedState.OBTAINING_IPADDR) {
+                return wifiInfo.networkId
+            }
+        }
+    }
+    return 0
+}

--- a/android/app/src/main/java/network/mysterium/net/NetworkState.kt
+++ b/android/app/src/main/java/network/mysterium/net/NetworkState.kt
@@ -1,4 +1,4 @@
-package network.mysterium.service.core
+package network.mysterium.net
 
 data class NetworkState(
         val wifiConnected: Boolean = false,

--- a/android/app/src/main/java/network/mysterium/service/core/MysteriumCoreService.kt
+++ b/android/app/src/main/java/network/mysterium/service/core/MysteriumCoreService.kt
@@ -29,10 +29,6 @@ interface MysteriumCoreService : IBinder {
 
     fun stopNode()
 
-    fun startConnectivityChecker(nodeRepository: NodeRepository)
-
-    fun networkConnState(): MutableLiveData<NetworkState>
-
     fun getActiveProposal(): ProposalViewItem?
 
     fun setActiveProposal(proposal: ProposalViewItem?)

--- a/android/app/src/main/java/network/mysterium/service/core/MysteriumCoreService.kt
+++ b/android/app/src/main/java/network/mysterium/service/core/MysteriumCoreService.kt
@@ -31,7 +31,7 @@ interface MysteriumCoreService : IBinder {
 
     fun startConnectivityChecker(nodeRepository: NodeRepository)
 
-    fun networkConnState(): MutableLiveData<NetworkConnState>
+    fun networkConnState(): MutableLiveData<NetworkState>
 
     fun getActiveProposal(): ProposalViewItem?
 

--- a/android/app/src/main/java/network/mysterium/service/core/NetworkState.kt
+++ b/android/app/src/main/java/network/mysterium/service/core/NetworkState.kt
@@ -1,0 +1,9 @@
+package network.mysterium.service.core
+
+data class NetworkState(
+        val wifiConnected: Boolean = false,
+        val wifiNetworkId: Int = 0,
+        val cellularConnected: Boolean = false
+) {
+    val connected: Boolean get() = wifiConnected or cellularConnected
+}


### PR DESCRIPTION
- Remove usage of deprecated API in `MysteriumAndroidCoreService`
- Replace a polling job with a callback
- Simplify