### PR TITLE
Set default filter to any if quality service is not available

### DIFF
--- a/android/app/src/main/java/network/mysterium/ui/ProposalViewItem.kt
+++ b/android/app/src/main/java/network/mysterium/ui/ProposalViewItem.kt
@@ -41,7 +41,7 @@ class ProposalViewItem constructor(
     var countryFlagImage: Bitmap? = null
     var serviceTypeResID: Int = R.drawable.service_openvpn
     var qualityResID: Int = R.drawable.quality_unknown
-    var qualityLevel: QualityLevel = QualityLevel.ANY
+    var qualityLevel: QualityLevel = QualityLevel.UNKNOWN
     var countryName: String = ""
     var isFavorite: Boolean = false
     var isFavoriteResID: Int = R.drawable.ic_star_border_black_24dp
@@ -98,7 +98,7 @@ class ProposalViewItem constructor(
                 QualityLevel.HIGH -> R.drawable.quality_high
                 QualityLevel.MEDIUM -> R.drawable.quality_medium
                 QualityLevel.LOW -> R.drawable.quality_low
-                QualityLevel.ANY -> R.drawable.quality_unknown
+                QualityLevel.UNKNOWN -> R.drawable.quality_unknown
             }
         }
     }

--- a/android/app/src/main/java/network/mysterium/ui/ProposalsFragment.kt
+++ b/android/app/src/main/java/network/mysterium/ui/ProposalsFragment.kt
@@ -191,7 +191,7 @@ class ProposalsFragment : Fragment() {
             proposalsFilterQualityValue.text = getString(R.string.proposals_filter_quality_value_any)
         } else {
             proposalsFilterQualityValue.text = when(filter.quality.level) {
-                QualityLevel.ANY -> getString(R.string.quality_level_any)
+                QualityLevel.UNKNOWN -> getString(R.string.quality_level_any)
                 QualityLevel.HIGH -> getString(R.string.quality_level_high)
                 QualityLevel.MEDIUM -> getString(R.string.quality_level_medium)
                 QualityLevel.LOW -> getString(R.string.quality_level_low)
@@ -270,4 +270,3 @@ data class ProposalHeaderItem(val title: String) : BaseItem() {
         headerText.text = title
     }
 }
-

--- a/android/app/src/main/java/network/mysterium/ui/ProposalsQualityFilterFragment.kt
+++ b/android/app/src/main/java/network/mysterium/ui/ProposalsQualityFilterFragment.kt
@@ -98,7 +98,7 @@ data class QualityItem(val ctx: Context, val quality: ProposalFilterQuality, val
         super.bind(holder)
         val text: TextView = holder.containerView.findViewById(R.id.proposal_quality_filter_item_text)
         text.text = when(quality.level) {
-            QualityLevel.ANY -> ctx.getString(R.string.quality_level_any)
+            QualityLevel.UNKNOWN -> ctx.getString(R.string.quality_level_any)
             QualityLevel.HIGH -> ctx.getString(R.string.quality_level_high)
             QualityLevel.MEDIUM -> ctx.getString(R.string.quality_level_medium)
             QualityLevel.LOW -> ctx.getString(R.string.quality_level_low)

--- a/android/app/src/main/java/network/mysterium/ui/ProposalsViewModel.kt
+++ b/android/app/src/main/java/network/mysterium/ui/ProposalsViewModel.kt
@@ -61,14 +61,14 @@ enum class ProposalSortType(val type: Int) {
 }
 
 enum class QualityLevel(val level: Int) {
-    ANY(0),
+    UNKNOWN(0),
     LOW(1),
     MEDIUM(2),
     HIGH(3);
 
     companion object {
         fun parse(level: Int): QualityLevel {
-            return values().find { it.level == level } ?: ANY
+            return values().find { it.level == level } ?: UNKNOWN
         }
     }
 }
@@ -255,7 +255,7 @@ class ProposalsViewModel(private val sharedViewModel: SharedViewModel, private v
         return listOf(
                 ProposalFilterQuality(QualityLevel.HIGH, false),
                 ProposalFilterQuality(QualityLevel.MEDIUM, false),
-                ProposalFilterQuality(QualityLevel.ANY, false)
+                ProposalFilterQuality(QualityLevel.UNKNOWN, false)
         )
     }
 
@@ -334,8 +334,9 @@ class ProposalsViewModel(private val sharedViewModel: SharedViewModel, private v
                 // Filter by quality level.
                 .filter {
                     when (filter.quality.level) {
-                        QualityLevel.ANY -> true
-                        else -> filter.quality.level <= it.qualityLevel
+                        QualityLevel.UNKNOWN -> true
+                        // Include proposals with unknown quality by default.
+                        else -> filter.quality.level <= it.qualityLevel || it.qualityLevel == QualityLevel.UNKNOWN
                     }
                 }
                 // Filter by unreachable nodes.


### PR DESCRIPTION
Currently, if quality oracle is not available we are showing 0 proposals with a default filter set to HIGH quality.
If quality oracle returns nothing we are showing all proposals with unknown quality.

https://github.com/mysteriumnetwork/node/issues/2663