### PR TITLE
Attempt to improve native crash context available in the play console

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -48,6 +48,7 @@ def enableSeparateBuildPerCPUArchitecture = false
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
+    ndkVersion rootProject.ext.ndkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -81,6 +82,9 @@ android {
         versionCode getVersionCode()
         versionName getVersionName()
         multiDexEnabled true
+        ndk {
+            debugSymbolLevel 'FULL'
+        }
 
         buildConfigField "String", "BUGFENDER_KEY", "\"76DAzZtiLE5AYx7uvIWD8I16EqgReOHc\""
         buildConfigField "String", "INTERCOM_API_KEY", "\"android_sdk-e480f3fce4f2572742b13c282c453171c1715516\""

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -11,3 +11,5 @@
 -dontwarn me.pushy.**
 -keep class me.pushy.** { *; }
 -keep class android.support.v4.app.** { *; }
+-keep class go.** { *; }
+-keep class mysterium.** { *; }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,6 +7,7 @@ buildscript {
         minSdkVersion = 24
         compileSdkVersion = 29
         targetSdkVersion = 29
+        ndkVersion = '21.4.7075529' // r21e - https://developer.android.com/ndk/downloads#lts-downloads
     }
     repositories {
         google()


### PR DESCRIPTION
Attempt to add some context to the empty stacktraces in the Play console, e.g.:
```
*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
pid: 0, tid: 0 >>> network.mysterium.vpn <<<

backtrace:
  #00  pc 00000000008c5ae8  /data/app/network.mysterium.vpn-LilZ81z24oOMtB5UE8zyrA==/split_config.arm64_v8a.apk!lib/arm64-v8a/libgojni.so (offset 0x1000)
```
I have checked the mobile-node AAR - it contains libraries, libgojni.so in particular _with_ debug symbol information. So it must be the android build process or the play console that strips them out. Or something I don't quite understand.

I have no way of reproducing this locally, so it's just a try.