### PR TITLE
Fixed filtering by mime-type in account import file selecting. 

### DIFF
--- a/android/app/src/main/java/updated/mysterium/vpn/ui/create/account/CreateAccountActivity.kt
+++ b/android/app/src/main/java/updated/mysterium/vpn/ui/create/account/CreateAccountActivity.kt
@@ -30,6 +30,8 @@ import java.io.InputStreamReader
 class CreateAccountActivity : BaseActivity() {
 
     private companion object {
+    	const val MIME_TYPE_JSON = "application/json"
+	const val MIME_TYPE_BINARY_FILE = "application/octet-stream"
         const val KEY_REQUEST_CODE = 0
         const val TAG = "CreateAccountActivity"
     }
@@ -88,9 +90,9 @@ class CreateAccountActivity : BaseActivity() {
         val intent = Intent(Intent.ACTION_GET_CONTENT)
         intent.type = "*/*"
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
-            intent.putExtra(Intent.EXTRA_MIME_TYPES, arrayOf("application/octet-stream"))
+            intent.putExtra(Intent.EXTRA_MIME_TYPES, arrayOf(MIME_TYPE_BINARY_FILE))
         } else {
-            intent.putExtra(Intent.EXTRA_MIME_TYPES, arrayOf("application/json"))
+            intent.putExtra(Intent.EXTRA_MIME_TYPES, arrayOf(MIME_TYPE_JSON))
         }
         startActivityForResult(intent, KEY_REQUEST_CODE)
     }

--- a/android/app/src/main/java/updated/mysterium/vpn/ui/create/account/CreateAccountActivity.kt
+++ b/android/app/src/main/java/updated/mysterium/vpn/ui/create/account/CreateAccountActivity.kt
@@ -2,6 +2,7 @@ package updated.mysterium.vpn.ui.create.account
 
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.text.method.HideReturnsTransformationMethod
 import android.text.method.PasswordTransformationMethod
@@ -29,7 +30,6 @@ import java.io.InputStreamReader
 class CreateAccountActivity : BaseActivity() {
 
     private companion object {
-        const val MIME_TYPE_JSON = "application/json"
         const val KEY_REQUEST_CODE = 0
         const val TAG = "CreateAccountActivity"
     }
@@ -87,8 +87,11 @@ class CreateAccountActivity : BaseActivity() {
     private fun uploadKey() {
         val intent = Intent(Intent.ACTION_GET_CONTENT)
         intent.type = "*/*"
-        val mimeTypes = arrayOf(MIME_TYPE_JSON)
-        intent.putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes)
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
+            intent.putExtra(Intent.EXTRA_MIME_TYPES, arrayOf("application/octet-stream"))
+        } else {
+            intent.putExtra(Intent.EXTRA_MIME_TYPES, arrayOf("application/json"))
+        }
         startActivityForResult(intent, KEY_REQUEST_CODE)
     }
 


### PR DESCRIPTION
application/json mime-type supported only from Adnroid 10 what was causing impossibility to select keystore.json file on account import intent.