### PR TITLE
Filter unsupported nodes by default

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -89,7 +89,7 @@ android {
         buildConfigField "String", "BUGFENDER_KEY", "\"76DAzZtiLE5AYx7uvIWD8I16EqgReOHc\""
         buildConfigField "String", "INTERCOM_API_KEY", "\"android_sdk-e480f3fce4f2572742b13c282c453171c1715516\""
         buildConfigField "String", "INTERCOM_APP_ID", "\"h7hlm9on\""
-        buildConfigField "String", "NODE_VERSION", "\"0.52.0-1branch-testnet3-b-1\""
+        buildConfigField "String", "NODE_VERSION", "\"0.61.0\""
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
@@ -227,10 +227,12 @@ dependencies {
 
     //Mysterium
     implementation "network.mysterium:terms:0.0.32"
-    implementation "network.mysterium:mobile-node:0.52.0-1branch-testnet3-b-1"
+    implementation "network.mysterium:mobile-node:0.61.0"
     // Change NODE_VERSION in defaultConfig if updating version of mobile-node
     // Comment network.mysterium:mobile-node and replace with your local path to use local node build.
     //implementation files('/Users/macbook/AndroidStudioProjects/Mysterium.aar')
+    // implementation files('/Users/soffokl/go/src/github.com/mysteriumnetwork/node/build/package/Mysterium.aar')
+
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation(

--- a/android/app/src/main/java/updated/mysterium/vpn/network/usecase/FilterUseCase.kt
+++ b/android/app/src/main/java/updated/mysterium/vpn/network/usecase/FilterUseCase.kt
@@ -19,6 +19,7 @@ class FilterUseCase(
     companion object {
         const val ALL_NODES_FILTER_ID = 0
         private const val SERVICE_TYPE = "wireguard"
+        private const val NAT_COMPATIBILITY = "auto"
         private val selectedResources = listOf(
             R.drawable.all_filters_selected,
             R.drawable.media_filters_selected,
@@ -69,6 +70,7 @@ class FilterUseCase(
                 presetID = filterId.toLong()
                 refresh = true
                 serviceType = SERVICE_TYPE
+                natCompatibility = "auto"
             }
             nodeRepository.getProposalsByFilterId(proposalRequest).map {
                 NodeEntity(it)

--- a/android/app/src/main/java/updated/mysterium/vpn/network/usecase/NodesUseCase.kt
+++ b/android/app/src/main/java/updated/mysterium/vpn/network/usecase/NodesUseCase.kt
@@ -18,6 +18,7 @@ class NodesUseCase(
     companion object {
         const val ALL_COUNTRY_CODE = "ALL_COUNTRY"
         private const val SERVICE_TYPE = "wireguard"
+        private const val NAT_COMPATIBILITY = "auto"
     }
 
     fun initDeferredNode(deferredNode: DeferredNode) {
@@ -84,6 +85,7 @@ class NodesUseCase(
         val proposalsRequest = GetProposalsRequest().apply {
             this.refresh = true
             serviceType = SERVICE_TYPE
+            natCompatibility = NAT_COMPATIBILITY
         }
         return nodeRepository.proposals(proposalsRequest)
             .map { NodeEntity(it) }


### PR DESCRIPTION
This is a part of the https://github.com/mysteriumnetwork/node/issues/3709

This enables the filtering of unsupported nodes by default, but we should implement a configuration option to enable/disable it:
https://github.com/mysteriumnetwork/mysterium-vpn-mobile/issues/447
https://github.com/mysteriumnetwork/mysterium-vpn-desktop/issues/184
