### PR TITLE
[MG-588] Fast scroll on node proposals

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -227,6 +227,9 @@ dependencies {
     //WorkManager
     implementation "androidx.work:work-runtime-ktx:2.7.1"
 
+    //Fast scroll
+    implementation "me.zhanghai.android.fastscroll:library:1.2.0"
+
     //Mysterium
     // Change NODE_VERSION in defaultConfig if updating version of mobile-node
     implementation "network.mysterium:terms:0.0.50"

--- a/android/app/src/main/java/updated/mysterium/vpn/ui/nodes/list/FilterActivity.kt
+++ b/android/app/src/main/java/updated/mysterium/vpn/ui/nodes/list/FilterActivity.kt
@@ -6,6 +6,7 @@ import android.view.View
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.bumptech.glide.Glide
+import me.zhanghai.android.fastscroll.FastScrollerBuilder
 import network.mysterium.vpn.R
 import network.mysterium.vpn.databinding.ActivityFilterBinding
 import org.koin.android.ext.android.inject
@@ -134,6 +135,14 @@ class FilterActivity : BaseActivity() {
         binding.nodesRecyclerView.apply {
             layoutManager = LinearLayoutManager(this@FilterActivity)
             adapter = nodeListAdapter
+            FastScrollerBuilder(this).useMd2Style().apply {
+                ContextCompat.getDrawable(this@FilterActivity, R.drawable.thumb_drawable_scrolling)
+                    ?.let {
+                        setThumbDrawable(it)
+                    }
+                disableScrollbarAutoHide()
+                build()
+            }
         }
     }
 

--- a/android/app/src/main/java/updated/mysterium/vpn/ui/nodes/list/FilterActivity.kt
+++ b/android/app/src/main/java/updated/mysterium/vpn/ui/nodes/list/FilterActivity.kt
@@ -133,13 +133,13 @@ class FilterActivity : BaseActivity() {
             navigateToConnection(it)
         }
         binding.nodesRecyclerView.apply {
-            layoutManager = LinearLayoutManager(this@FilterActivity)
+            val context = this@FilterActivity
+            layoutManager = LinearLayoutManager(context)
             adapter = nodeListAdapter
             FastScrollerBuilder(this).useMd2Style().apply {
-                ContextCompat.getDrawable(this@FilterActivity, R.drawable.thumb_drawable_scrolling)
-                    ?.let {
-                        setThumbDrawable(it)
-                    }
+                ContextCompat.getDrawable(context, R.drawable.thumb_drawable_scrolling)?.let {
+                    setThumbDrawable(it)
+                }
                 disableScrollbarAutoHide()
                 build()
             }

--- a/android/app/src/main/res/drawable/thumb_drawable_scrolling.xml
+++ b/android/app/src/main/res/drawable/thumb_drawable_scrolling.xml
@@ -1,0 +1,13 @@
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle"
+    android:tint="@color/manual_connect_scrollbar_grey">
+
+    <corners android:radius="8dp" />
+
+    <padding android:top="4dp" android:bottom="4dp" />
+
+    <size android:width="8dp" android:height="52dp" />
+
+    <solid android:color="@android:color/white" />
+</shape>

--- a/android/app/src/main/res/layout/activity_filter.xml
+++ b/android/app/src/main/res/layout/activity_filter.xml
@@ -131,10 +131,10 @@
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/nodesRecyclerView"
-        style="@style/ScrollbarRecyclerView"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_marginStart="@dimen/margin_padding_size_small_medium"
+        android:layout_marginEnd="@dimen/margin_padding_size_xsmall"
         android:layout_marginTop="@dimen/margin_padding_size_small"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/nodeTextView"


### PR DESCRIPTION
Added third-party library for fast scroll ability on node proposals screen.

Now user can pull on the scrollbar thumb for a fast vertical scroll

Related issue: https://github.com/mysteriumnetwork/mysterium-vpn-mobile/issues/764